### PR TITLE
fix setwd bug on set_kit.R

### DIFF
--- a/kits/R-Python/set_kit.R
+++ b/kits/R-Python/set_kit.R
@@ -22,9 +22,6 @@ set_kit <- function(proj_name, proj_path, lang = "r"){
     ## Create project in path 
     dir.create(file.path(proj_path, proj_name), recursive = TRUE)
     
-    ## Set up working directory
-    setwd(file.path(proj_path, proj_name))
-    
     ## Create file structure
     ### first level
     ### main folders of a project
@@ -213,6 +210,9 @@ set_kit <- function(proj_name, proj_path, lang = "r"){
     cat("\n")
     cat("```")
     sink()
+    
+    #Then you can set wd here
+    setwd(file.path(proj_path, proj_name))
 
     print("Your project is ready to go")
   }


### PR DESCRIPTION
If the working directory is changed at the beggining of folder creation, then the rest of functions should not reference the full path (proj_path/proj_name) anymore. Otherwise all functions are trying to write on proj_path/proj_name/proj_path/proj_name which throws an error. The easiest way to solve it is just to change working directory at the end of the function.